### PR TITLE
Add support for glob patterns

### DIFF
--- a/tasks/embed.coffee
+++ b/tasks/embed.coffee
@@ -15,7 +15,7 @@ module.exports = (grunt) ->
     done = @async()
 
     @files.forEach (file) =>
-      srcFile = file.orig.src
+      srcFile = file.src
       if typeof srcFile isnt 'string'
         if srcFile.length > 1
           grunt.log.warn 'Multiple source files supplied; only the first will be used.'


### PR DESCRIPTION
When using a glob pattern grunt-embed fails with: `">> Source file "/my/path/**/*.html" not found."`

This pull request fixes this issue.

my configuration:

``` js
    embed: {
      options: {
        threshold: '300KB',
      },
      emailTemplate: {
        files: [
          {expand: true, src: ['src/**/*.html'], dest: 'build/', filter: 'isFile'},
        ]
      }
```
