### PR TITLE
Wait until all files are embedded

### DIFF
--- a/tasks/embed.coffee
+++ b/tasks/embed.coffee
@@ -12,7 +12,9 @@ path = require 'path'
 module.exports = (grunt) ->
 
   grunt.registerMultiTask 'embed', 'Converts external scripts and stylesheets into embedded ones.', ->
-    done = @async()
+    complete = @async()
+    jobs = @files.length
+    done = () -> complete() if not jobs -= 1
 
     @files.forEach (file) =>
       srcFile = file.orig.src


### PR DESCRIPTION
We need to embed several files, and we are struggling with a situation where the second file has not yet been processed, but the task has already been completed.

```js
grunt.initConfig({
  embed: {
    build: {
        files: {
            "_index.html": "app/index.html",
            "_home.html": "app/home.html"
        }
    }
  }
})
```